### PR TITLE
Remove unused SkiaSharp dependency

### DIFF
--- a/build/props/dependencies.props
+++ b/build/props/dependencies.props
@@ -12,6 +12,5 @@
 		<PackageReference Update="EPiServer.CMS.UI.Core" Version="$(CmsCoreVersion)" />
 		<PackageReference Update="EPiServer.CMS.AspNetCore.HtmlHelpers" Version="$(CmsCoreVersion)" />
 		<PackageReference Update="Microsoft.Extensions.FileProviders.Embedded" Version="5.0.0" />
-		<PackageReference Update="SkiaSharp.NativeAssets.Linux.NoDependencies" Version="2.80.3" />
 	</ItemGroup>
 </Project>


### PR DESCRIPTION
I couldn't find any references to SkiaSharp library in code so I've removed it because the referenced version is vulnerable (https://github.com/advisories/GHSA-j7hp-h8jx-5ppr)